### PR TITLE
Enable mean miner on architectures without AVX2 instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,13 @@ sudo: false
 language: cpp
 env:
   - JOB=quick
-  - JOB=demo30
+  - JOB=demo30x1
 matrix:
   include:
     - os: osx
       osx_image: xcode8.3 # [`xcode8.3` is Xcode 8.3.3 on OS X 10.12](https://docs.travis-ci.com/user/reference/osx#OS-X-Version)
       language: generic
       env: JOB=quick
-  allow_failures:
-    - env: JOB=demo30
-  fast_finish: true
 before_script:
   - case "${TRAVIS_OS_NAME:?}" in linux) LIBV=LD_LIBRARY_PATH;; osx) LIBV=DYLD_LIBRARY_PATH;; esac
   - echo "The library path variable name is ${LIBV:?}"
@@ -21,4 +18,4 @@ before_script:
 script:
   - ( cd src && make libblake2b.so; )
   - if test quick = "${JOB:?}"; then ( cd src && env ${LIBV:?}="${LIBP:?}" make test example; ); fi
-  - if test demo30 = "${JOB:?}"; then ( cd src && env ${LIBV:?}="${LIBP:?}" make demo30; ); fi
+  - if test demo30x1 = "${JOB:?}"; then ( cd src && env ${LIBV:?}="${LIBP:?}" make demo30x1; ); fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,8 +55,14 @@ lean25:	siphash.h cuckoo.h lean_miner.hpp lean_miner.cpp Makefile
 mean16:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
 	$(GPP) -o $@ -mavx2 -DXBITS=0 -DNSIPHASH=8 -DEDGEBITS=15 mean_miner.cpp $(LIBS)
 
+mean16x1:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
+	$(GPP) -o $@ -DXBITS=0 -DNSIPHASH=1 -DEDGEBITS=15 mean_miner.cpp $(LIBS)
+
 mean16s:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
 	$(GPP) -o $@ -DSAVEEDGES -mavx2 -DXBITS=0 -DNSIPHASH=8 -DEDGEBITS=15 mean_miner.cpp $(LIBS)
+
+mean16sx1:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
+	$(GPP) -o $@ -DSAVEEDGES -DXBITS=0 -DNSIPHASH=1 -DEDGEBITS=15 mean_miner.cpp $(LIBS)
 
 mean20:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
 	$(GPP) -o $@ -mavx2 -DXBITS=2 -DNSIPHASH=8 -DEDGEBITS=19 mean_miner.cpp $(LIBS)
@@ -67,11 +73,20 @@ mean25:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
 mean28:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
 	$(GPP) -o $@ -mavx2 -DXBITS=6 -DCOMPRESSROUND=10 -DNSIPHASH=8 -DEDGEBITS=27 mean_miner.cpp $(LIBS)
 
+mean28x1:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
+	$(GPP) -o $@ -DXBITS=6 -DCOMPRESSROUND=10 -DNSIPHASH=1 -DEDGEBITS=27 mean_miner.cpp $(LIBS)
+
 mean28s:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
 	$(GPP) -o $@ -mavx2 -DSAVEEDGES  -DXBITS=6 -DNSIPHASH=8 -DEDGEBITS=27 mean_miner.cpp $(LIBS)
 
+mean28sx1:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
+	$(GPP) -o $@ -DSAVEEDGES  -DXBITS=6 -DNSIPHASH=1 -DEDGEBITS=27 mean_miner.cpp $(LIBS)
+
 mean30:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
 	$(GPP) -o $@ -mavx2 -DNSIPHASH=8 -DEDGEBITS=29 mean_miner.cpp $(LIBS)
+
+mean30x1:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
+	$(GPP) -o $@ -DNSIPHASH=1 -DEDGEBITS=29 mean_miner.cpp $(LIBS)
 
 cutrix30:	mean_miner.cu Makefile
 	nvcc -o $@ -DEDGEBITS=29 -arch sm_35 mean_miner.cu $(LIBS)
@@ -79,8 +94,14 @@ cutrix30:	mean_miner.cu Makefile
 mean30s:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
 	$(GPP) -o $@ -mavx2 -DSAVEEDGES -DNSIPHASH=8 -DEDGEBITS=29 mean_miner.cpp $(LIBS)
 
+mean30sx1:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
+	$(GPP) -o $@ -DSAVEEDGES -DNSIPHASH=1 -DEDGEBITS=29 mean_miner.cpp $(LIBS)
+
 demo30:	mean30s
 	time ./mean30s -n 25
+
+demo30x1:	mean30sx1
+	time ./mean30sx1 -n 25
 
 mean32:	cuckoo.h siphash.h mean_miner.hpp mean_miner.cpp Makefile
 	$(GPP) -o $@ -mavx2 -DEXPANDROUND=8 -DCOMPRESSROUND=22 -DXBITS=8 -DNSIPHASH=8 -DEDGEBITS=31 mean_miner.cpp $(LIBS)


### PR DESCRIPTION
Notes:
* `mean28` has a `-DCOMPRESSROUND=10` that `mean28s` does not - why?
* This`mean.*x1` naming convention does not change the meaning of the current binary names. An alternative naming convention would be following lean i.e. rename e.g. `mean30s` as `mean30sx8` and `mean30sx1` as `mean30s`.