### PR TITLE
Use unaligned load for avx2 in these two spots

### DIFF
--- a/src/mean_miner.hpp
+++ b/src/mean_miner.hpp
@@ -320,7 +320,7 @@ public:
 #if NSIPHASH == 8
     static const __m256i vxmask = {XMASK, XMASK, XMASK, XMASK};
     static const __m256i vyzmask = {YZMASK, YZMASK, YZMASK, YZMASK};
-    const __m256i vinit = _mm256_load_si256((__m256i *)&sip_keys);
+    const __m256i vinit = _mm256_loadu_si256((__m256i *)&sip_keys);
     __m256i v0, v1, v2, v3, v4, v5, v6, v7;
     const u32 e2 = 2 * edge + uorv;
     __m256i vpacket0 = _mm256_set_epi64x(e2+6, e2+4, e2+2, e2+0);
@@ -433,7 +433,7 @@ public:
 #if NSIPHASH == 8
     static const __m256i vxmask = {XMASK, XMASK, XMASK, XMASK};
     static const __m256i vyzmask = {YZMASK, YZMASK, YZMASK, YZMASK};
-    const __m256i vinit = _mm256_load_si256((__m256i *)&sip_keys);
+    const __m256i vinit = _mm256_loadu_si256((__m256i *)&sip_keys);
     __m256i vpacket0, vpacket1, vhi0, vhi1;
     __m256i v0, v1, v2, v3, v4, v5, v6, v7;
 #endif

--- a/src/mean_miner.hpp
+++ b/src/mean_miner.hpp
@@ -265,6 +265,17 @@ public:
   bool showall;
   pthread_barrier_t barry;
 
+  void* operator new(size_t size) noexcept {
+    void* newobj;
+    int tmp = posix_memalign(&newobj, 32, sizeof(edgetrimmer));
+
+    if (tmp != 0) {
+      return nullptr;
+    }
+
+    return newobj;
+  }
+
   void touch(u8 *p, const offset_t n) {
     for (offset_t i=0; i<n; i+=4096)
       *(u32 *)(p+i) = 0;
@@ -320,7 +331,7 @@ public:
 #if NSIPHASH == 8
     static const __m256i vxmask = {XMASK, XMASK, XMASK, XMASK};
     static const __m256i vyzmask = {YZMASK, YZMASK, YZMASK, YZMASK};
-    const __m256i vinit = _mm256_loadu_si256((__m256i *)&sip_keys);
+    const __m256i vinit = _mm256_load_si256((__m256i *)&sip_keys);
     __m256i v0, v1, v2, v3, v4, v5, v6, v7;
     const u32 e2 = 2 * edge + uorv;
     __m256i vpacket0 = _mm256_set_epi64x(e2+6, e2+4, e2+2, e2+0);
@@ -433,7 +444,7 @@ public:
 #if NSIPHASH == 8
     static const __m256i vxmask = {XMASK, XMASK, XMASK, XMASK};
     static const __m256i vyzmask = {YZMASK, YZMASK, YZMASK, YZMASK};
-    const __m256i vinit = _mm256_loadu_si256((__m256i *)&sip_keys);
+    const __m256i vinit = _mm256_load_si256((__m256i *)&sip_keys);
     __m256i vpacket0, vpacket1, vhi0, vhi1;
     __m256i v0, v1, v2, v3, v4, v5, v6, v7;
 #endif

--- a/src/mean_miner.hpp
+++ b/src/mean_miner.hpp
@@ -253,9 +253,15 @@ typedef u32 zbucket32[NTRIMMEDZ];
 // maintains set of trimmable edges
 class edgetrimmer {
 public:
-  siphash_keys sip_keys;
   yzbucket<ZBUCKETSIZE> *buckets;
   yzbucket<TBUCKETSIZE> *tbuckets;
+
+  // DO NOT move this siphash_keys struct declaration or put any new declarations
+  // (except the two bucket pointers) above this, or this code will break
+  // on Linux! Sip_keys must be 32 byte aligned for the _mm256_load_si256 
+  // to work below.
+  siphash_keys sip_keys;
+
   zbucket32 *tedges;
   zbucket16 *tzs;
   zbucket8 *tdegs;
@@ -264,17 +270,6 @@ public:
   u32 nthreads;
   bool showall;
   pthread_barrier_t barry;
-
-  void* operator new(size_t size) noexcept {
-    void* newobj;
-    int tmp = posix_memalign(&newobj, 32, sizeof(edgetrimmer));
-
-    if (tmp != 0) {
-      return nullptr;
-    }
-
-    return newobj;
-  }
 
   void touch(u8 *p, const offset_t n) {
     for (offset_t i=0; i<n; i+=4096)

--- a/src/mean_miner.hpp
+++ b/src/mean_miner.hpp
@@ -265,9 +265,11 @@ public:
   bool showall;
   pthread_barrier_t barry;
 
+#if NSIPHASH > 4
+
   void* operator new(size_t size) noexcept {
     void* newobj;
-    int tmp = posix_memalign(&newobj, 32, sizeof(edgetrimmer));
+    int tmp = posix_memalign(&newobj, NSIPHASH * sizeof(u32), sizeof(edgetrimmer));
 
     if (tmp != 0) {
       return nullptr;
@@ -275,6 +277,8 @@ public:
 
     return newobj;
   }
+
+#endif
 
   void touch(u8 *p, const offset_t n) {
     for (offset_t i=0; i<n; i+=4096)


### PR DESCRIPTION
It appears as though these unaligned loads are needed on Linux for mean_miners that have more than one siphash round. I tested with clang-5.0, clang-3.9 and gcc-5.4 and they all segfault without the loadu's. I also tried to align the struct manually, but that didn't seem to fix the problem, strangely. These changes shouldn't really affect performance as these functions are only called a few times, I think (and newer chips handle unaligned loads well these days).

Also, I set up my travis instance to test on trusty since I noticed that your travis config is using that version of Ubuntu, while I am on xenial. No change. 

I also changed travis to test demo30x8, since only demo30x1 was being built/tested. It failed on trusty and xenial. Perhaps it would be advisable to test one of these other mean_miner versions on your travis setup?

Thanks,
Kelly