### PR TITLE
Add SSE2 variants for Siphash24 function

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -158,6 +158,12 @@ lean30:	siphash.h cuckoo.h lean_miner.hpp lean_miner.cpp Makefile
 lean30.1:	siphash.h cuckoo.h lean_miner.hpp lean_miner.cpp Makefile
 	$(GPP) -o $@ -DATOMIC -DPART_BITS=1 -DEDGEBITS=29 lean_miner.cpp $(LIBS)
 
+lean30x2:	siphash.h siphashxN.h cuckoo.h lean_miner.hpp lean_miner.cpp Makefile
+	$(GPP) -o $@ -mno-avx2 -DATOMIC -DNSIPHASH=2 -DEDGEBITS=29 lean_miner.cpp $(LIBS)
+	
+lean30x4:	siphash.h siphashxN.h cuckoo.h lean_miner.hpp lean_miner.cpp Makefile
+	$(GPP) -o $@ -mno-avx2 -DATOMIC -DNSIPHASH=4 -DEDGEBITS=29 lean_miner.cpp $(LIBS)
+	
 lean30x8:	siphash.h cuckoo.h lean_miner.hpp lean_miner.cpp Makefile
 	$(GPP) -o $@ -mavx2 -DNSIPHASH=8 -DATOMIC -DEDGEBITS=29 lean_miner.cpp $(LIBS)
 

--- a/src/siphashxN.h
+++ b/src/siphashxN.h
@@ -1,5 +1,6 @@
 #ifndef INCLUDE_SIPHASHXN_H
 #define INCLUDE_SIPHASHXN_H
+
 #ifdef __AVX2__
 
 #define ADD(a, b) _mm256_add_epi64(a, b)
@@ -12,15 +13,15 @@
 #define ROT21(x) _mm256_or_si256(_mm256_slli_epi64(x,21),_mm256_srli_epi64(x,43))
 #define ROT32(x) _mm256_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))
 
-#elif 0 && defined __SSE2__
+#elif defined __SSE2__
 
 #define ADD(a, b) _mm_add_epi64(a, b)
 #define XOR(a, b) _mm_xor_si128(a, b)
 #define ROT13(x) _mm_or_si128(_mm_slli_epi64(x,13),_mm_srli_epi64(x,51))
-#define ROT16(x) _mm_or_si128(_mm_slli_epi64(x,16),_mm_srli_epi64(x,48))
 #define ROT17(x) _mm_or_si128(_mm_slli_epi64(x,17),_mm_srli_epi64(x,47))
 #define ROT21(x) _mm_or_si128(_mm_slli_epi64(x,21),_mm_srli_epi64(x,43))
-#define ROT32(x) _mm_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))
+#define ROT32(x) _mm_shuffle_epi32  (x, _MM_SHUFFLE(2,3,0,1))
+#define ROT16(x) _mm_shufflehi_epi16(_mm_shufflelo_epi16(x, _MM_SHUFFLE(2,1,0,3)), _MM_SHUFFLE(2,1,0,3))
 
 #endif
 
@@ -150,62 +151,73 @@ void siphash24x16(const siphash_keys *keys, const u64 *indices, u64 *hashes) {
   _mm256_store_si256((__m256i *)(hashes+12), XOR(XOR(vC,vD),XOR(vE,vF)));
 }
 
-#elif 0 && defined __SSE2__
+#elif defined __SSE2__
 
-// 4-way sipHash-2-4 specialized to precomputed key and 8 byte nonces
+// 2-way sipHash-2-4 specialized to precomputed key and 8 byte nonces
 void siphash24x2(const siphash_keys *keys, const u64 *indices, u64 *hashes) {
-  const __m128i packet = _mm_load_si128((__m128i *)indices);
-  const __m128i init0  = _mm_load_si128((__m128i *)&keys);
-  const __m128i init1  = _mm_load_si128((__m128i *)(&keys + 2));
-
-  __m128i v3 = _mm_unpackhi_epi64(init1, init1); // _mm_shuffle_epi32(init1, 0xee);
-  __m128i v0 = _mm_unpacklo_epi64(init0, init0); // _mm_shuffle_epi32(init0, 0x44);
-  __m128i v1 = _mm_unpackhi_epi64(init0, init0); // _mm_shuffle_epi32(init0, 0xee);
-  __m128i v2 = _mm_unpacklo_epi64(init1, init1); // _mm_shuffle_epi32(init1, 0x44);
-
-  v3 = XOR(v3,packet);
+  __m128i v0, v1, v2, v3, mi;
+  v0 = _mm_set1_epi64x(keys->k0);
+  v1 = _mm_set1_epi64x(keys->k1);
+  v2 = _mm_set1_epi64x(keys->k2);
+  v3 = _mm_set1_epi64x(keys->k3);
+  mi = _mm_load_si128((__m128i *)indices);
+	
+  v3 = XOR (v3, mi);
   SIPROUNDXN; SIPROUNDXN;
-  v0 = XOR(v0,packet);
-  v2 = XOR(v2,_mm128_broadcastq_epi64(_mm_cvtsi64_si128(0xff)));
+  v0 = XOR (v0, mi);
+  
+  v2 = XOR (v2, _mm_set1_epi64x(0xffLL));
   SIPROUNDXN; SIPROUNDXN; SIPROUNDXN; SIPROUNDXN;
-  _mm128_store_si256((__m256i *)hashes, XOR(XOR(v0,v1),XOR(v2,v3)));
+  mi = XOR(XOR(v0,v1),XOR(v2,v3));
+  
+  _mm_store_si128((__m128i *)hashes, mi);
 }
 
-// 8-way sipHash-2-4 specialized to precomputed key and 8 byte nonces
+// 4-way sipHash-2-4 specialized to precomputed key and 8 byte nonces
 void siphash24x4(const siphash_keys *keys, const u64 *indices, u64 *hashes) {
-  const __m256i init = _mm128_set_epi64x(keys->k3, keys->k2, keys->k1, keys->k0);
-  const __m256i packet0 = _mm128_load_si256((__m256i *)indices);
-  const __m256i packet4 = _mm128_load_si256((__m256i *)(indices+4));
-  __m256i v3 = _mm128_permute4x64_epi64(init, 0xFF);
-  __m256i v0 = _mm128_permute4x64_epi64(init, 0x00);
-  __m256i v1 = _mm128_permute4x64_epi64(init, 0x55);
-  __m256i v2 = _mm128_permute4x64_epi64(init, 0xAA);
-  __m256i v7 = _mm128_permute4x64_epi64(init, 0xFF);
-  __m256i v4 = _mm128_permute4x64_epi64(init, 0x00);
-  __m256i v5 = _mm128_permute4x64_epi64(init, 0x55);
-  __m256i v6 = _mm128_permute4x64_epi64(init, 0xAA);
+  __m128i v0, v1, v2, v3, mi, v4, v5, v6, v7, m2;
+  v0 = _mm_set1_epi64x(keys->k0);
+  v1 = _mm_set1_epi64x(keys->k1);
+  v2 = _mm_set1_epi64x(keys->k2);
+  v3 = _mm_set1_epi64x(keys->k3);
+  v4 = _mm_set1_epi64x(keys->k0);
+  v5 = _mm_set1_epi64x(keys->k1);
+  v6 = _mm_set1_epi64x(keys->k2);
+  v7 = _mm_set1_epi64x(keys->k3);
 
-  v3 = XOR(v3,packet0); v7 = XOR(v7,packet4);
+  mi = _mm_load_si128((__m128i *)indices);
+  m2 = _mm_load_si128((__m128i *)(indices + 2));
+
+  v3 = XOR (v3, mi);
+  v7 = XOR (v7, m2);
   SIPROUNDX2N; SIPROUNDX2N;
-  v0 = XOR(v0,packet0); v4 = XOR(v4,packet4);
-  v2 = XOR(v2,_mm128_broadcastq_epi64(_mm_cvtsi64_si128(0xff)));
-  v6 = XOR(v6,_mm128_broadcastq_epi64(_mm_cvtsi64_si128(0xff)));
+  v0 = XOR (v0, mi);
+  v4 = XOR (v4, m2);
+
+  v2 = XOR (v2, _mm_set1_epi64x(0xffLL));
+  v6 = XOR (v6, _mm_set1_epi64x(0xffLL));
   SIPROUNDX2N; SIPROUNDX2N; SIPROUNDX2N; SIPROUNDX2N;
-  _mm128_store_si256((__m256i *)hashes, XOR(XOR(v0,v1),XOR(v2,v3)));
-  _mm128_store_si256((__m256i *)(hashes+4), XOR(XOR(v4,v5),XOR(v6,v7)));
+  mi = XOR(XOR(v0,v1),XOR(v2,v3));
+  m2 = XOR(XOR(v4,v5),XOR(v6,v7));
+  
+  _mm_store_si128((__m128i *)hashes,		mi);
+  _mm_store_si128((__m128i *)(hashes + 2),m2);
 }
 #endif
 
 #ifndef NSIPHASH
 // how many siphash24 to compute in parallel
-// currently 1, 4, 8 are supported, but
-// more than 1 requires the use of avx2
+// currently 1, 2, 4, 8 are supported, but
+// more than 1 requires the use of sse2 or avx2
+// more than 4 requires the use of avx2
 #define NSIPHASH 1
 #endif
 
 void siphash24xN(const siphash_keys *keys, const u64 *indices, u64 * hashes) {
 #if NSIPHASH == 1
   *hashes = siphash24(keys, *indices);
+#elif NSIPHASH == 2  
+  siphash24x2(keys, indices, hashes); 
 #elif NSIPHASH == 4
   siphash24x4(keys, indices, hashes);
 #elif NSIPHASH == 8


### PR DESCRIPTION
Added `siphash24x2 `and `siphash24x4 `variants with SSE2 instruction optimization. Also replaced ROT16 in the SSE2 variant with shuffle instead of shift instructions.

There are two build examples, `lean30x2 `and `lean30x4 `in the `Makefile`, with a flag to disable AVX2.

Tested on the lean miner against `verify30 `with nounces 63 and 140902 (on a single thread).