### PR TITLE
[Don't Merge] Modifications to make direct inclusion by other libs easier

### DIFF
--- a/src/cuckatoo/Makefile
+++ b/src/cuckatoo/Makefile
@@ -36,7 +36,7 @@ lean29x8:	../crypto/siphash.h cuckatoo.h  bitmap.hpp compress.hpp graph.hpp lean
 mean19x8:	cuckatoo.h  bitmap.hpp graph.hpp ../crypto/siphash.h mean.hpp mean.cpp Makefile
 	$(GPP) -o $@ -mavx2 -DXBITS=2 -DNSIPHASH=8 -DEDGEBITS=19 mean.cpp $(LIBS)
 
-mean29x4:	cuckatoo.h  bitmap.hpp graph.hpp ../crypto/siphash.h mean.hpp mean.cpp Makefile
+mean29x4:	cuckatoo.h  param_map.h bitmap.hpp graph.hpp ../crypto/siphash.h mean.hpp mean.cpp Makefile
 	$(GPP) -o $@ -mno-avx2 -DNSIPHASH=4 -DEDGEBITS=29 mean.cpp $(LIBS)
 
 mean29x8:	cuckatoo.h  bitmap.hpp graph.hpp ../crypto/siphash.h mean.hpp mean.cpp Makefile

--- a/src/cuckatoo/cuckatoo.h
+++ b/src/cuckatoo/cuckatoo.h
@@ -1,10 +1,46 @@
 // Cuck(at)oo Cycle, a memory-hard proof-of-work
 // Copyright (c) 2013-2019 John Tromp
-
 #include <stdint.h> // for types uint32_t,uint64_t
 #include <string.h> // for functions strlen, memset
+#include <atomic>   // for atomic bool
 #include "../crypto/blake2.h"
 #include "../crypto/siphash.h"
+#include "param_map.h"
+
+/////////////////////////////////////////////////////////////////
+// Declarations to make it easier for callers to link as required
+/////////////////////////////////////////////////////////////////
+
+// convention to prepend to called functions
+#ifndef CALL_CONVENTION
+#define CALL_CONVENTION
+#endif
+
+// if this is set, immediately stop all solvers and return to caller gracefully
+std::atomic_bool SHOULD_STOP(false);
+
+// All solver functions should check for SHOULD_STOP
+// as appropriate, the idea being solvers should stop and exit
+// gracefully from the run_solver function
+CALL_CONVENTION void stop_solver() {
+	SHOULD_STOP = true;
+}
+
+// Maximum number of PROOFSIZE-length cycles to return to caller
+#define MAX_SOLS 10
+
+// Ability to squash printf output at compile time, if desired
+#ifndef SQUASH_OUTPUT
+#define SQUASH_OUTPUT 0
+#endif
+
+#if SQUASH_OUTPUT
+#define printf(fmt, ...) (0)
+#endif
+
+//////////////////////////////////////////////////////////////////
+// END caller QOL
+//////////////////////////////////////////////////////////////////
 
 // proof-of-work parameters
 #ifndef EDGEBITS

--- a/src/cuckatoo/cuckatoo.h
+++ b/src/cuckatoo/cuckatoo.h
@@ -26,9 +26,6 @@ CALL_CONVENTION void stop_solver() {
 	SHOULD_STOP = true;
 }
 
-// Maximum number of PROOFSIZE-length cycles to return to caller
-#define MAX_SOLS 10
-
 // Ability to squash printf output at compile time, if desired
 #ifndef SQUASH_OUTPUT
 #define SQUASH_OUTPUT 0

--- a/src/cuckatoo/mean.cpp
+++ b/src/cuckatoo/mean.cpp
@@ -8,6 +8,73 @@
 // arbitrary length of header hashed into siphash key
 #define HEADERLEN 80
 
+CALL_CONVENTION int run_solver(char* header,
+                               int header_length,
+                               u32* sol_nonces[PROOFSIZE],
+                               int* n_solutions,
+                               ParamMap params)
+{
+  u32 nthreads = params.get("nthreads");
+  u32 ntrims = params.get("ntrims");
+  u32 nonce = params.get("nonce");
+  u32 range = params.get("range");
+  bool showcycle = params.get("showcycle");
+  bool allrounds = params.get("allrounds");
+
+  struct timeval time0, time1;
+  u32 timems;
+  printf("Looking for %d-cycle on cuckoo%d(\"%s\",%d", PROOFSIZE, NODEBITS, header, nonce);
+  if (range > 1)
+    printf("-%d", nonce+range-1);
+  printf(") with 50%% edges\n");
+
+  solver_ctx ctx(nthreads, ntrims, allrounds, showcycle);
+
+  u64 sbytes = ctx.sharedbytes();
+  u32 tbytes = ctx.threadbytes();
+  int sunit,tunit;
+  for (sunit=0; sbytes >= 10240; sbytes>>=10,sunit++) ;
+  for (tunit=0; tbytes >= 10240; tbytes>>=10,tunit++) ;
+  printf("Using %d%cB bucket memory at %lx,\n", sbytes, " KMGT"[sunit], (u64)ctx.trimmer.buckets);
+  printf("%dx%d%cB thread memory at %lx,\n", nthreads, tbytes, " KMGT"[tunit], (u64)ctx.trimmer.tbuckets);
+  printf("%d-way siphash, and %d buckets.\n", NSIPHASH, NX);
+
+  u32 sumnsols = 0;
+  for (u32 r = 0; r < range; r++) {
+    gettimeofday(&time0, 0);
+    ctx.setheadernonce(header, header_length, nonce + r);
+    printf("nonce %d k0 k1 k2 k3 %llx %llx %llx %llx\n", nonce+r, ctx.trimmer.sip_keys.k0, ctx.trimmer.sip_keys.k1, ctx.trimmer.sip_keys.k2, ctx.trimmer.sip_keys.k3);
+    u32 nsols = ctx.solve();
+    gettimeofday(&time1, 0);
+    timems = (time1.tv_sec-time0.tv_sec)*1000 + (time1.tv_usec-time0.tv_usec)/1000;
+    printf("Time: %d ms\n", timems);
+
+    for (unsigned s = 0; s < nsols; s++) {
+      printf("Solution");
+      word_t *prf = &ctx.sols[s * PROOFSIZE];
+      for (u32 i = 0; i < PROOFSIZE; i++)
+        printf(" %jx", (uintmax_t)prf[i]);
+      printf("\n");
+      int pow_rc = verify(prf, &ctx.trimmer.sip_keys);
+      if (pow_rc == POW_OK) {
+        printf("Verified with cyclehash ");
+        unsigned char cyclehash[32];
+        blake2b((void *)cyclehash, sizeof(cyclehash), (const void *)prf, sizeof(proof), 0, 0);
+        for (int i=0; i<32; i++)
+          printf("%02x", cyclehash[i]);
+        printf("\n");
+      } else {
+        printf("FAILED due to %s\n", errstr[pow_rc]);
+      }
+    }
+    sumnsols += nsols;
+  }
+  printf("%d total solutions\n", sumnsols);
+  return 0;
+}
+
+
+
 int main(int argc, char **argv) {
   u32 nthreads = 1;
   u32 ntrims = EDGEBITS > 30 ? 96 : 68;
@@ -18,8 +85,6 @@ int main(int argc, char **argv) {
 #else
   bool showcycle = 0;
 #endif
-  struct timeval time0, time1;
-  u32 timems;
   char header[HEADERLEN];
   u32 len;
   bool allrounds = false;
@@ -59,52 +124,16 @@ int main(int argc, char **argv) {
         break;
     }
   }
-  printf("Looking for %d-cycle on cuckoo%d(\"%s\",%d", PROOFSIZE, NODEBITS, header, nonce);
-  if (range > 1)
-    printf("-%d", nonce+range-1);
-  printf(") with 50%% edges\n");
 
-  solver_ctx ctx(nthreads, ntrims, allrounds, showcycle);
+	ParamMap params;
+	params.set("allrounds", allrounds);
+	params.set("nonce", nonce);
+	params.set("range", range);
+	params.set("ntrims", ntrims);
+	params.set("showcycle", showcycle);
+	params.set("nthreads", nthreads);
 
-  u64 sbytes = ctx.sharedbytes();
-  u32 tbytes = ctx.threadbytes();
-  int sunit,tunit;
-  for (sunit=0; sbytes >= 10240; sbytes>>=10,sunit++) ;
-  for (tunit=0; tbytes >= 10240; tbytes>>=10,tunit++) ;
-  printf("Using %d%cB bucket memory at %lx,\n", sbytes, " KMGT"[sunit], (u64)ctx.trimmer.buckets);
-  printf("%dx%d%cB thread memory at %lx,\n", nthreads, tbytes, " KMGT"[tunit], (u64)ctx.trimmer.tbuckets);
-  printf("%d-way siphash, and %d buckets.\n", NSIPHASH, NX);
-
-  u32 sumnsols = 0;
-  for (u32 r = 0; r < range; r++) {
-    gettimeofday(&time0, 0);
-    ctx.setheadernonce(header, sizeof(header), nonce + r);
-    printf("nonce %d k0 k1 k2 k3 %llx %llx %llx %llx\n", nonce+r, ctx.trimmer.sip_keys.k0, ctx.trimmer.sip_keys.k1, ctx.trimmer.sip_keys.k2, ctx.trimmer.sip_keys.k3);
-    u32 nsols = ctx.solve();
-    gettimeofday(&time1, 0);
-    timems = (time1.tv_sec-time0.tv_sec)*1000 + (time1.tv_usec-time0.tv_usec)/1000;
-    printf("Time: %d ms\n", timems);
-
-    for (unsigned s = 0; s < nsols; s++) {
-      printf("Solution");
-      word_t *prf = &ctx.sols[s * PROOFSIZE];
-      for (u32 i = 0; i < PROOFSIZE; i++)
-        printf(" %jx", (uintmax_t)prf[i]);
-      printf("\n");
-      int pow_rc = verify(prf, &ctx.trimmer.sip_keys);
-      if (pow_rc == POW_OK) {
-        printf("Verified with cyclehash ");
-        unsigned char cyclehash[32];
-        blake2b((void *)cyclehash, sizeof(cyclehash), (const void *)prf, sizeof(proof), 0, 0);
-        for (int i=0; i<32; i++)
-          printf("%02x", cyclehash[i]);
-        printf("\n");
-      } else {
-        printf("FAILED due to %s\n", errstr[pow_rc]);
-      }
-    }
-    sumnsols += nsols;
-  }
-  printf("%d total solutions\n", sumnsols);
-  return 0;
+	u32* sols[PROOFSIZE];
+	int n_sols;
+	run_solver(header, sizeof(header), sols, &n_sols, params);
 }

--- a/src/cuckatoo/param_map.h
+++ b/src/cuckatoo/param_map.h
@@ -10,9 +10,6 @@ class ParamMap {
 	public:
 		void set(string name, int value);
 		int get(string name);
-		// call above in a more linker-friendly way
-		CALL_CONVENTION void set_param(const char* name, unsigned int name_len, int value);
-		CALL_CONVENTION int get_param(const char* name, unsigned int name_len);
 	private:
 		unordered_map<string, int> pmap;
 };
@@ -28,11 +25,11 @@ int ParamMap::get(string name){
 }
 
 // intended for linkage
-CALL_CONVENTION void ParamMap::set_param(const char* name, unsigned int name_len, int value) {
-	set(string(name, name_len), value);
+CALL_CONVENTION void set_param(ParamMap* map, const char* name, unsigned int name_len, int value) {
+	map->set(string(name, name_len), value);
 }
 
 // intended for linkage
-CALL_CONVENTION int ParamMap::get_param(const char* name, unsigned int name_len){
-	return get(string(name, name_len));
+CALL_CONVENTION int get_param(ParamMap* map, const char* name, unsigned int name_len){
+	return map->get(string(name, name_len));
 }

--- a/src/cuckatoo/param_map.h
+++ b/src/cuckatoo/param_map.h
@@ -1,0 +1,38 @@
+// parameter map for solvers to faciliate linked code
+#include <unordered_map>
+using namespace std;
+
+#ifndef CALL_CONVENTION
+#define CALL_CONVENTION
+#endif
+
+class ParamMap {
+	public:
+		void set(string name, int value);
+		int get(string name);
+		// call above in a more linker-friendly way
+		CALL_CONVENTION void set_param(const char* name, unsigned int name_len, int value);
+		CALL_CONVENTION int get_param(const char* name, unsigned int name_len);
+	private:
+		unordered_map<string, int> pmap;
+};
+
+// set a parameter for the solver
+void ParamMap::set(string name, int value){
+	pmap[name] = value;
+}
+
+// get a parameter from the solver
+int ParamMap::get(string name){
+	return pmap[name];
+}
+
+// intended for linkage
+CALL_CONVENTION void ParamMap::set_param(const char* name, unsigned int name_len, int value) {
+	set(string(name, name_len), value);
+}
+
+// intended for linkage
+CALL_CONVENTION int ParamMap::get_param(const char* name, unsigned int name_len){
+	return get(string(name, name_len));
+}


### PR DESCRIPTION
Just playing with this now to make suggestions using cuckatoo/mean.cpp, intended for discussion at the moment.

* Add an atomic bool and a stop_solver() function, that should allow callers to interrupt the solver process and exit cleanly (after building a new block, for instance). All solvers would need to check for SHOULD_STOP in appropriate places and return.
* Add a CALL_CONVENTION definition to prepend where exposure to callers is required
* Definition that squashes all printf output when set
* Split a run_solver function away from main, so linkers have something to link to directly
* Create a ParamMap class and use that to pass in user-configurable parameters to the solver. The ParamMap class can expose functions that allow it to be manipulated. (So rust ffi can just hold an opaque reference to a param map and call functions on it directly).

I'd hope with this in place, changes to solver functionality would be minimal (except for the need to incorporate the SHOULD_STOP variable).

Still need to think about:

* How to return statistics for each device to the caller, particularly CUDA. I think it's desirable to use each solver as intended, passing in a range and let the solver mutate the header (instead of doing it beforehand and passing in range=1 each time), but this won't work very well unless there's a way to return device-specific statistics to the caller about what's going on.
* Device the best way of returning solutions to the caller.