### PR TITLE
Fix cuckoo CUDA code for compilation on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.exe
+build/


### PR DESCRIPTION
This is needed on Windows because `cl.exe` doesn't support statements in expressions like [gcc](https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html) does.