### PR TITLE
Use device number supplied in args

### DIFF
--- a/src/cuckaroo/mean.cu
+++ b/src/cuckaroo/mean.cu
@@ -734,7 +734,7 @@ int main(int argc, char **argv) {
         params.cpuload = false;
         break;
       case 'd':
-        params.device = atoi(optarg);
+        device = params.device = atoi(optarg);
         break;
       case 'h':
         len = strlen(optarg)/2;

--- a/src/cuckatoo/lean.cu
+++ b/src/cuckatoo/lean.cu
@@ -399,7 +399,7 @@ int main(int argc, char **argv) {
         print_log("DEFAULTS\n  cuda%d -d %d -h \"\" -m %d -n %d -r %d -b %d -t %d\n", NODEBITS, device, tp.ntrims, nonce, range, tp.blocks, tp.tpb);
         exit(0);
       case 'd':
-        params.device = atoi(optarg);
+        device = params.device = atoi(optarg);
         break;
       case 'h':
         len = strlen(optarg)/2;

--- a/src/cuckatoo/mean.cu
+++ b/src/cuckatoo/mean.cu
@@ -736,7 +736,7 @@ int main(int argc, char **argv) {
         params.cpuload = false;
         break;
       case 'd':
-        params.device = atoi(optarg);
+        device = params.device = atoi(optarg);
         break;
       case 'E':
         params.expand = atoi(optarg);

--- a/src/cuckoo/mean.cu
+++ b/src/cuckoo/mean.cu
@@ -829,7 +829,7 @@ int main(int argc, char **argv) {
         params.cpuload = false;
         break;
       case 'd':
-        params.device = atoi(optarg);
+        device = params.device = atoi(optarg);
         break;
       case 'E':
         params.expand = atoi(optarg);


### PR DESCRIPTION
It looks like the device initialization code wasn't using the device number passed on the command line, making it impossible to test any device other than number 0.