### PR TITLE
Add id field to Solution struct

### DIFF
--- a/src/cuckaroo/cuckaroo.hpp
+++ b/src/cuckaroo/cuckaroo.hpp
@@ -79,6 +79,7 @@ struct SolverParams {
 // Solutions result structs to be instantiated by caller,
 // and filled by solver if desired
 struct Solution {
+ u64 id = 0;
  u64 nonce = 0;
  u64 proof[PROOFSIZE];
 };

--- a/src/cuckatoo/cuckatoo.h
+++ b/src/cuckatoo/cuckatoo.h
@@ -73,6 +73,7 @@ struct SolverParams {
 // Solutions result structs to be instantiated by caller,
 // and filled by solver if desired
 struct Solution {
+ u64 id = 0;
  u64 nonce = 0;
  u64 proof[PROOFSIZE];
 };


### PR DESCRIPTION
Just adds an option ID field to the Solution struct, that allows callers to associate an identifier with a particular solution.