### PR TITLE
Assert and bitwise operators

### DIFF
--- a/src/cuckatoo/mean.cu
+++ b/src/cuckatoo/mean.cu
@@ -511,7 +511,7 @@ struct edgetrimmer {
     checkCudaErrors_V(cudaMalloc((void**)&bufferA, bufferSize));
     bufferAB = bufferA + nonoverlap;
     bufferB  = bufferA + bufferSize - sizeB;
-    assert(NA & (NA-1) == 0); // ensure NA is a 2 power
+    assert((NA & (NA-1)) == 0); // ensure NA is a 2 power
     assert(NA * NEPS_B * NRB1 >= NEPS_A * NX); // ensure disjoint source dest in SeedB
     assert(bufferA + sizeA * NRB2 / NX <= bufferB); // ensure disjoint source dest in 2nd phase of round 0
     assert(bufferA + sizeA == bufferB + sizeB * NRB2 / NX); // ensure alignment of overlap


### PR DESCRIPTION
Assert expressions involving bitwise operators seem to require an additional set of parentheses so that the conditional can be evaluated in the intended manner (i.e. to ensure that NA is a power of 2).