### PR TITLE
fix for issue #86

### DIFF
--- a/src/cuckaroo/mean.cu
+++ b/src/cuckaroo/mean.cu
@@ -721,12 +721,12 @@ CALL_CONVENTION void fill_default_params(SolverParams* params) {
   trimparams tp;
   params->device = 0;
   params->ntrims = tp.ntrims;
-  params->genablocks = tp.genA.blocks;
+  params->genablocks = min(tp.genA.blocks, NEDGES/EDGE_BLOCK_SIZE/tp.genA.tpb);
   params->genatpb = tp.genA.tpb;
   params->genbtpb = tp.genB.tpb;
   params->trimtpb = tp.trim.tpb;
   params->tailtpb = tp.tail.tpb;
-  params->recoverblocks = tp.recover.blocks;
+  params->recoverblocks = min(tp.recover.blocks, NEDGES/EDGE_BLOCK_SIZE/tp.recover.tpb);
   params->recovertpb = tp.recover.tpb;
   params->cpuload = false;
 }

--- a/src/cuckatoo/mean.cu
+++ b/src/cuckatoo/mean.cu
@@ -873,12 +873,12 @@ CALL_CONVENTION void fill_default_params(SolverParams* params) {
   params->device = 0;
   params->ntrims = tp.ntrims;
   params->expand = tp.expand;
-  params->genablocks = tp.genA.blocks;
+  params->genablocks = min(tp.genA.blocks, NEDGES/tp.genA.tpb);
   params->genatpb = tp.genA.tpb;
   params->genbtpb = tp.genB.tpb;
   params->trimtpb = tp.trim.tpb;
   params->tailtpb = tp.tail.tpb;
-  params->recoverblocks = tp.recover.blocks;
+  params->recoverblocks = min(tp.recover.blocks, NEDGES/tp.recover.tpb);
   params->recovertpb = tp.recover.tpb;
   params->cpuload = false;
 }

--- a/src/cuckoo/mean.cu
+++ b/src/cuckoo/mean.cu
@@ -826,12 +826,12 @@ CALL_CONVENTION void fill_default_params(SolverParams* params) {
   params->device = 0;
   params->ntrims = tp.ntrims;
   params->expand = tp.expand;
-  params->genablocks = tp.genA.blocks;
+  params->genablocks = min(tp.genA.blocks, NEDGES/tp.genA.tpb);
   params->genatpb = tp.genA.tpb;
   params->genbtpb = tp.genB.tpb;
   params->trimtpb = tp.trim.tpb;
   params->tailtpb = tp.tail.tpb;
-  params->recoverblocks = tp.recover.blocks;
+  params->recoverblocks = min(tp.recover.blocks, NEDGES/tp.recover.tpb);
   params->recovertpb = tp.recover.tpb;
   params->cpuload = false;
 }


### PR DESCRIPTION
The default block counts for genA and recover are clamped to valid values, but you can still get the old behavior using command-line switches.