### PR TITLE
fix mean trimmer size format warnings on older gcc

### DIFF
--- a/src/cuckoo/mean.hpp
+++ b/src/cuckoo/mean.hpp
@@ -897,7 +897,7 @@ public:
     }
     rdtsc1 = __rdtsc();
     if (showall || (!id && !(round & (round+1))))
-      printf("trimedges1 id %d round %2d size %u rdtsc: %lu\n", id, round, sumsize/sizeof(u32), rdtsc1-rdtsc0);
+      printf("trimedges1 id %d round %2d size %zu rdtsc: %lu\n", id, round, sumsize/sizeof(u32), rdtsc1-rdtsc0);
     tcounts[id] = sumsize/sizeof(u32);
   }
 
@@ -957,7 +957,7 @@ public:
       sumsize += TRIMONV ? dst.storev(buckets, vx) : dst.storeu(buckets, vx);
     }
     rdtsc1 = __rdtsc();
-    if (showall || !id) printf("trimrename1 id %d round %2d size %u rdtsc: %lu maxnnid %d\n", id, round, sumsize/sizeof(u32), rdtsc1-rdtsc0, maxnnid);
+    if (showall || !id) printf("trimrename1 id %d round %2d size %zu rdtsc: %lu maxnnid %d\n", id, round, sumsize/sizeof(u32), rdtsc1-rdtsc0, maxnnid);
     assert(maxnnid < NYZ2);
     tcounts[id] = sumsize/sizeof(u32);
   }


### PR DESCRIPTION
Prints this on older Linux,

```log
g++ -O3 -std=c++11 -DEDGEBITS=29 -DPROOFSIZE=42 -DNSIPHASH=1 -I../../../external/cuckoo/src/cuckoo solve_main.cpp ../../../external/cuckoo/src/crypto/blake2b-ref.c -o ../cuckoo_solve_29_42 -pthread
In file included from solve_main.cpp:25:
../../../external/cuckoo/src/cuckoo/mean.hpp: In instantiation of ‘void edgetrimmer::trimedges1(u32, u32) [with bool TRIMONV = true; u32 = unsigned int]’:
../../../external/cuckoo/src/cuckoo/mean.hpp:1004:30:   required from here
../../../external/cuckoo/src/cuckoo/mean.hpp:900:48: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
  900 |       printf("trimedges1 id %d round %2d size %u rdtsc: %lu\n", id, round, sumsize/sizeof(u32), rdtsc1-rdtsc0);
      |                                               ~^                           ~~~~~~~~~~~~~~~~~~~
      |                                                |                                  |
      |                                                unsigned int                       long unsigned int
      |                                               %lu
../../../external/cuckoo/src/cuckoo/mean.hpp: In instantiation of ‘void edgetrimmer::trimedges1(u32, u32) [with bool TRIMONV = false; u32 = unsigned int]’:
../../../external/cuckoo/src/cuckoo/mean.hpp:1014:31:   required from here
../../../external/cuckoo/src/cuckoo/mean.hpp:900:48: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
  900 |       printf("trimedges1 id %d round %2d size %u rdtsc: %lu\n", id, round, sumsize/sizeof(u32), rdtsc1-rdtsc0);
      |                                               ~^                           ~~~~~~~~~~~~~~~~~~~
      |                                                |                                  |
      |                                                unsigned int                       long unsigned int
      |                                               %lu
../../../external/cuckoo/src/cuckoo/mean.hpp: In instantiation of ‘void edgetrimmer::trimrename1(u32, u32) [with bool TRIMONV = true; u32 = unsigned int]’:
../../../external/cuckoo/src/cuckoo/mean.hpp:1017:23:   required from here
../../../external/cuckoo/src/cuckoo/mean.hpp:960:67: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
  960 |     if (showall || !id) printf("trimrename1 id %d round %2d size %u rdtsc: %lu maxnnid %d\n", id, round, sumsize/sizeof(u32), rdtsc1-rdtsc0, maxnnid);
      |                                                                  ~^                                      ~~~~~~~~~~~~~~~~~~~
      |                                                                   |                                             |
      |                                                                   unsigned int                                  long unsigned int
      |                                                                  %lu
../../../external/cuckoo/src/cuckoo/mean.hpp: In instantiation of ‘void edgetrimmer::trimrename1(u32, u32) [with bool TRIMONV = false; u32 = unsigned int]’:
../../../external/cuckoo/src/cuckoo/mean.hpp:1019:23:   required from here
../../../external/cuckoo/src/cuckoo/mean.hpp:960:67: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘long unsigned int’ [-Wformat=]
  960 |     if (showall || !id) printf("trimrename1 id %d round %2d size %u rdtsc: %lu maxnnid %d\n", id, round, sumsize/sizeof(u32), rdtsc1-rdtsc0, maxnnid);
      |                                                                  ~^                                      ~~~~~~~~~~~~~~~~~~~
      |                                                                   |                                             |
      |                                                                   unsigned int                                  long unsigned int
      |                                                                  %lu
```